### PR TITLE
Fix source url for hand tracking example

### DIFF
--- a/examples/showcase/handtracking/index.html
+++ b/examples/showcase/handtracking/index.html
@@ -465,7 +465,7 @@
            title="Or open with `<ctrl> + <alt> + i`.">Visual Inspector</a>
       
       
-        <a id="exampleViewSource" class="btn" href="https://glitch.com/edit/#!/bristle-curly-primula?path=index.html%3A14%3A0" target="_blank"
+        <a id="exampleViewSource" class="btn" href="https://github.com/aframevr/aframe/blob/master/examples/showcase/hand-tracking/index.html" target="_blank"
            title="View the HTML on GitHub">View Source</a>
       
     </div>


### PR DESCRIPTION
Hello, thank you for maintaining awesome library.

I've just noticed this URL (https://glitch.com/edit/#!/bristle-curly-primula) will be redirected to 404 page currently.

![image](https://github.com/aframevr/aframevr.github.io/assets/1796864/9cbfa112-0d9a-41ad-baee-c516f061f35d)

