### PR TITLE
Add Pagefind search indexing via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Generate Pagefind index
+        run: npx pagefind@1.5.0 --site .
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
This adds a GitHub Actions workflow that generates Pagefind search indexes on each push to master, then deploys the site via GitHub Pages artifacts.

### Why

The aframe-site now uses [Pagefind](https://pagefind.app/) instead of Algolia for documentation search. The Pagefind index needs to be generated from the static HTML files but should not be committed to git. This workflow generates it at deploy time.

### Required configuration

After merging, a repo maintainer needs to change the GitHub Pages source:

1. Go to **Settings > Pages**
2. Under **Build and deployment > Source**, change from **"Deploy from a branch"** to **"GitHub Actions"**

Without this change, the workflow will run but the site won't be served from the Actions artifact.

### How it works

1. a-frobot pushes the generated static site to this repo (as before)
2. The push triggers this workflow which:
   - Runs `npx pagefind@1 --site .` to generate search indexes
   - Uploads the entire directory (including the generated `pagefind/` folder) as a Pages artifact
   - Deploys to GitHub Pages

The Pagefind index files only exist in the deployed artifact, never in git history.