### PR TITLE
Full site build pipeline in GitHub Actions, replacing a-frobot

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,8 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches: [master]
+  repository_dispatch:
+    types: [deploy]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,18 +22,33 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          repository: aframevr/aframe-site
+          path: aframe-site
 
       - uses: actions/setup-node@v6
         with:
           node-version: 24
 
+      - name: Install dependencies
+        run: npm install --ignore-scripts --include=dev
+        working-directory: aframe-site
+
+      - name: Build docs
+        run: npm run bumpdocs
+        working-directory: aframe-site
+
+      - name: Generate site
+        run: npm run generate
+        working-directory: aframe-site
+
       - name: Generate Pagefind index
-        run: npx pagefind@1.5.0 --site .
+        run: npx pagefind@1.5.0 --site aframe-site/public
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: .
+          path: aframe-site/public
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,6 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
+  push:
+    branches: [master]
   repository_dispatch:
     types: [deploy]
   workflow_dispatch:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -47,7 +47,8 @@ jobs:
         working-directory: aframe-site
 
       - name: Generate Pagefind index
-        run: npx pagefind@1.5.0 --site aframe-site/public
+        run: npx pagefind --site public
+        working-directory: aframe-site
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,9 +29,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'npm'
+          cache-dependency-path: 'aframe-site/package-lock.json'
 
       - name: Install dependencies
-        run: npm install --ignore-scripts --include=dev
+        run: npm ci --ignore-scripts --include=dev
         working-directory: aframe-site
 
       - name: Build docs


### PR DESCRIPTION
## Configuration required (for repo owner)

1. **Create a fine-grained Personal Access Token (PAT)**
   - Go to https://github.com/settings/tokens?type=beta
   - Create a token scoped to the `aframevr/aframevr.github.io` repository
   - Grant "Actions: Read and write" permission (under Repository permissions)
   - This is the minimum permission needed to trigger `repository_dispatch`

2. **Add the PAT as a secret in `aframevr/aframe-site`**
   - Go to https://github.com/aframevr/aframe-site/settings/secrets/actions
   - Create a new repository secret named `DEPLOY_PAT` with the PAT value

3. **Add the same PAT as a secret in `aframevr/aframe`**
   - Go to https://github.com/aframevr/aframe/settings/secrets/actions
   - Create a new repository secret named `DEPLOY_PAT` with the same PAT value

4. **Merge the companion PRs**
   - `aframevr/aframe-site`: https://github.com/aframevr/aframe-site/pull/562
   - `aframevr/aframe`: https://github.com/aframevr/aframe/pull/5812

5. **Verify GitHub Pages is configured** in `aframevr/aframevr.github.io`
   - Go to Settings > Pages
   - Source should be set to "GitHub Actions" (not "Deploy from a branch")

You can skip reading from here.

## Current flow (a-frobot on AWS)

1. A push to `aframevr/aframe-site` or `aframevr/aframe` master triggers a webhook
2. The webhook hits a-frobot, a Node.js bot running on an AWS EC2 instance (supermedium/a-frobot)
3. a-frobot pulls the latest `aframe-site`, runs `npm run bumpdocs` and `npm run generate`
   - `bumpdocs` clears the npm cache for the latest versioned docs branch (docs-v1.7.0),
     removes the local multidep copy, reinstalls aframe from master, then runs `installdocs`
   - `installdocs` runs `multidep multidep.json` to download all versioned docs (0.1.0 to 1.7.0)
     from their respective `docs-v*` branches, then copies them into `src/docs/`
   - `generate` runs hexo clean + hexo generate to produce the static site in `public/`
4. a-frobot copies `public/*` into the local `aframevr.github.io` clone, commits, and pushes to master
5. That push triggers the `deploy-pages.yml` GitHub Actions workflow in `aframevr.github.io`
   which runs Pagefind on the static files and deploys to GitHub Pages

## New flow (GitHub Actions only, no AWS)

1. A push to `aframevr/aframe-site` master or `aframevr/aframe` master (docs/ path only)
   triggers a `trigger-deploy.yml` workflow in that repo
2. That workflow sends a `repository_dispatch` event (type: `deploy`) to `aframevr/aframevr.github.io`
3. The `deploy-pages.yml` workflow in `aframevr.github.io` runs the full build:
   - Checks out `aframevr/aframe-site`
   - Installs dependencies
   - Runs `npm run bumpdocs` (fetches fresh docs from aframe master + all versioned branches)
   - Runs `npm run generate` (hexo build)
   - Runs Pagefind to generate the search index
   - Deploys to GitHub Pages via `actions/deploy-pages`

This eliminates the AWS EC2 instance and the a-frobot bot entirely for site deployment.

## Changes in this PR

- Updated `deploy-pages.yml` to include the full build pipeline:
  - Added `repository_dispatch` trigger (type: `deploy`) and `workflow_dispatch` for manual triggers from the GitHub Actions UI
  - Checks out `aframevr/aframe-site` instead of the current repo
  - Installs Node.js dependencies
  - Runs `npm run bumpdocs` to fetch fresh docs from all aframe branches
  - Runs `npm run generate` to build the static site with hexo
  - Runs Pagefind on the generated `aframe-site/public` directory
  - Deploys `aframe-site/public` to GitHub Pages