### PR TITLE
Cache src/docs in CI to skip re-downloading old version tarballs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -38,6 +38,11 @@ jobs:
         run: npm ci --ignore-scripts --include=dev
         working-directory: aframe-site
 
+      - uses: actions/cache@v5
+        with:
+          path: aframe-site/src/docs
+          key: docs-${{ hashFiles('aframe-site/multidep.json') }}
+
       - name: Build docs
         run: npm run bumpdocs
         working-directory: aframe-site


### PR DESCRIPTION
## Summary
- Add `actions/cache@v5` step to cache `aframe-site/src/docs` between CI runs
- Cache key is based on `multidep.json` hash, so it invalidates when a new version is added
- On cache hit, only master and the latest versioned branch are re-fetched (older versions are skipped)

## Test plan
- [ ] Verify first CI run downloads all versions and caches `src/docs`
- [ ] Verify subsequent CI runs use the cache and only re-fetch master and latest version
- [ ] Verify adding a new version to `multidep.json` would bust the cache

**Note:** Depends on https://github.com/aframevr/aframe-site/pull/563 that replaces multidep with fetchDocs.